### PR TITLE
fix: license

### DIFF
--- a/tuxedo-drivers-kmod-common.spec
+++ b/tuxedo-drivers-kmod-common.spec
@@ -35,7 +35,7 @@ Name:     %{short}-kmod-common
 Version:  4.11.2
 Release:  1%{?dist}
 Summary:  Tuxedo drivers kmod common files
-License:  GPLv2
+License:  GPL-2.0-or-later
 URL:      https://github.com/gladion136/tuxedo-drivers-kmod
 
 Requires: %{short}-kmod >= %{version}

--- a/tuxedo-drivers-kmod.spec
+++ b/tuxedo-drivers-kmod.spec
@@ -7,7 +7,7 @@ Name:     tuxedo-drivers-kmod
 Version:  4.11.2
 Release:  1%{?dist}
 Summary:  Tuxedo drivers as kmod
-License:  GPLv2
+License:  GPL-2.0-or-later
 URL:      https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers
 
 Source:   %{url}/-/archive/v%{version}/tuxedo-drivers-v%{version}.tar.gz


### PR DESCRIPTION
`tuxedo-drivers` recently [switched their code to `GPL-2.0-or-later`](https://github.com/ublue-os/akmods/issues/129#issuecomment-2489834578), see [the license info](https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/blob/main/debian/copyright?ref_type=heads).

`tuxedo-drivers-kmod` is currently licensed as "GPLv2", which is [ambiguous](https://www.gnu.org/licenses/identify-licenses-clearly.html). Also, I think it's best practice to use [SPDX license identifiers](https://spdx.org/licenses/) (Fedora does).

*Addendum: Actually, the license is only changed to the `-or-later` version with v4.11.3 of tuxedo-drivers, so tuxedo-drivers-kmod should first be updated to that version.*

---

Thank you so much for starting to port tuxedo-drivers to akmod! 🙏 :heart: 🙏 